### PR TITLE
Fix missing actorName in useNotificationsRealtime payload

### DIFF
--- a/common/src/hooks/useNotificationsRealtime.ts
+++ b/common/src/hooks/useNotificationsRealtime.ts
@@ -41,6 +41,7 @@ export function useNotificationsRealtime(
             type: (n as any).type as NotificationType,
             groupId: (n as any).group_id as string,
             actorId: ((n as any).actor_id as string | null) ?? null,
+            actorName: ((n as any).actor_name as string | null) ?? null,
             read: (n as any).read as boolean,
             createdAt: (n as any).created_at as string,
           });


### PR DESCRIPTION
Fixes a build error introduced in #8.

`actorName` was added to the `Notification` type but the realtime payload mapping in `useNotificationsRealtime` was not updated to include it, causing a TypeScript compile error.

**Fix:** added `actorName: (n as any).actor_name ?? null` to the payload object in `useNotificationsRealtime.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)